### PR TITLE
feat(zotcli): add help, prompt snippet, and configurable ls/find fields

### DIFF
--- a/spells/zotcli/Makefile
+++ b/spells/zotcli/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 SPELL_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
-.PHONY: install install-dev test clean purge
+.PHONY: install install-dev test clean purge prompt
 
 install:
 	cd "$(SPELL_DIR)" && uv sync
@@ -19,3 +19,11 @@ clean:
 purge: clean
 	rm -rf "$(SPELL_DIR)/.venv"
 	@echo "Removed .venv"
+
+prompt:
+	@printf '%s\n' '# zotcli prompt snippet (_update_prompt style)'
+	@printf '%s\n' 'local zot_info="$$(__zotcli_ps1)"'
+	@printf '%s\n' 'if [[ -n "$$zot_info" ]]; then'
+	@printf '%s\n' "    local C_ZOT='\\[\\e[36m\\]'"
+	@printf '%s\n' '    PS1+="$${C_ZOT}$$zot_info$${C_RESET} "'
+	@printf '%s\n' 'fi'

--- a/spells/zotcli/README.md
+++ b/spells/zotcli/README.md
@@ -22,6 +22,7 @@ zotcli get jurafsky2026 --bibtex  # export BibTeX
 zotcli cd jurafsky2026         # enter item, see attachments
 zotcli ls                      # list attachments/notes
 zotcli get jurafsky2026:0-FullBook  # download attachment
+zotcli --help                 # top-level help
 ```
 
 ## Root Symbol
@@ -56,6 +57,7 @@ zotcli get jurafsky2026:0-FullBook  # download attachment
 | `zotcli ls --sort <field>` | Sort by: `name` (default), `date`, `type`, `creator`. |
 | `zotcli ls --reverse` | Reverse sort order. |
 | `zotcli ls --unfiled` | At root: list items not in any collection. |
+| `zotcli ls --fields <csv>` | Choose output columns: `label,title,citation_key,author,year,type,meta,key`. |
 
 ### Reading
 
@@ -73,6 +75,7 @@ zotcli get jurafsky2026:0-FullBook  # download attachment
 | `zotcli find <pattern> --scope library` | Search entire library (server-side). |
 | `zotcli find --tag <tag>` | Filter by tag. Multiple `--tag` flags = AND. |
 | `zotcli find --type <itemType>` | Filter by item type (`book`, `journalArticle`, etc). |
+| `zotcli find --fields <csv>` | Choose output columns (same aliases as `ls --fields`). |
 
 ### Exporting
 
@@ -129,6 +132,12 @@ _update_prompt() {
 
     # ... rest of prompt ...
 }
+```
+
+If you prefer a copy/paste snippet from build tooling:
+
+```sh
+make -C spells/zotcli prompt
 ```
 
 Output example when active: `zot://1.Books [5m ago]`

--- a/spells/zotcli/bin/zotcli
+++ b/spells/zotcli/bin/zotcli
@@ -30,6 +30,9 @@ export SPELL_DIR
 export ZOTCLI_FRESH="$FRESH"
 
 case "$SUBCOMMAND" in
+    -h|--help|help)
+        exec "$PYTHON" "$SPELL_DIR/lib/commands.py" help "${SUBARGS[@]}"
+        ;;
     py)
         exec "$PYTHON" "$SPELL_DIR/lib/shell_py.py" "${SUBARGS[@]}"
         ;;

--- a/spells/zotcli/completions/bash/zotcli.bash
+++ b/spells/zotcli/completions/bash/zotcli.bash
@@ -94,7 +94,7 @@ _zotcli() {
 
     COMP_WORDBREAKS="$OLD_IFS"
 
-    local subcommands="cd pwd ls tree cat get find sync connect config py off"
+    local subcommands="cd pwd ls tree cat get find sync connect config py off help"
 
     # Find the subcommand (skip global flags)
     local subcmd=""
@@ -116,7 +116,7 @@ _zotcli() {
         cd|ls)
             if [[ "$cur" == -* ]]; then
                 [[ "$subcmd" == "ls" ]] && \
-                    COMPREPLY=($(compgen -W "--sort --reverse --unfiled" -- "$cur"))
+                    COMPREPLY=($(compgen -W "--sort --reverse --unfiled --fields" -- "$cur"))
             else
                 compopt -o nospace 2>/dev/null
                 local IFS=$'\n'
@@ -139,7 +139,7 @@ _zotcli() {
 
         find)
             if [[ "$cur" == -* ]]; then
-                COMPREPLY=($(compgen -W "--field --scope --tag --type" -- "$cur"))
+                COMPREPLY=($(compgen -W "--field --scope --tag --type --fields" -- "$cur"))
             elif [[ "$prev" == "--scope" ]]; then
                 COMPREPLY=($(compgen -W "collection library" -- "$cur"))
             fi

--- a/spells/zotcli/lib/commands.py
+++ b/spells/zotcli/lib/commands.py
@@ -174,6 +174,7 @@ def cmd_ls(args):
     sort_key = _config.get_value(cfg, "ls.default_sort") or "name"
     reverse  = _config.get_value(cfg, "ls.sort_reverse") or False
     unfiled  = False
+    fields_spec = None
 
     # Parse flags
     positional = []
@@ -191,9 +192,21 @@ def cmd_ls(args):
         elif args[i] == "--unfiled":
             unfiled = True
             i += 1
+        elif args[i] == "--fields" and i + 1 < len(args):
+            fields_spec = args[i + 1]
+            i += 2
+        elif args[i].startswith("--fields="):
+            fields_spec = args[i][9:]
+            i += 1
         else:
             positional.append(args[i])
             i += 1
+
+    try:
+        fields = _fmt.normalize_fields(fields_spec, context="ls")
+    except ValueError as e:
+        _fmt.error(str(e))
+        sys.exit(1)
 
     st = _state.read_state()
     collections = _collections()
@@ -217,7 +230,7 @@ def cmd_ls(args):
             if not it.get("data", it).get("collections")
             and it.get("data", it).get("itemType") not in ("attachment", "note")
         ]
-        _fmt.print_ls([], unfiled_items, sort_key=sort_key, reverse=reverse)
+        _fmt.print_ls([], unfiled_items, sort_key=sort_key, reverse=reverse, fields=fields)
         return
 
     if not positional:
@@ -227,7 +240,7 @@ def cmd_ls(args):
         zot        = _zot()
         items      = _fetch_items(zot, target_key)
         _fmt.print_ls(sub_cols, items, sort_key=sort_key, reverse=reverse,
-                      current_collection_key=target_key)
+                      current_collection_key=target_key, fields=fields)
         return
 
     ref = positional[0]
@@ -244,7 +257,7 @@ def cmd_ls(args):
         zot      = _zot()
         items    = _fetch_items(zot, target_key)
         _fmt.print_ls(sub_cols, items, sort_key=sort_key, reverse=reverse,
-                      current_collection_key=target_key)
+                      current_collection_key=target_key, fields=fields)
     except ValueError:
         # Not a collection — treat as item reference, list children
         zot   = _zot()
@@ -446,7 +459,7 @@ def cmd_get(args):
 
 def cmd_find(args):
     if not args:
-        print("Usage: zotcli find <pattern> [--field <f>] [--scope library] [--tag <tag>] [--type <type>]",
+        print("Usage: zotcli find <pattern> [--field <f>] [--scope library] [--tag <tag>] [--type <type>] [--fields <csv>]",
               file=sys.stderr)
         sys.exit(1)
 
@@ -457,6 +470,7 @@ def cmd_find(args):
     scope      = "collection"
     tags       = []
     item_type  = None
+    out_fields = None
 
     i = 0
     while i < len(args):
@@ -484,11 +498,23 @@ def cmd_find(args):
         elif args[i].startswith("--type="):
             item_type = args[i][7:]
             i += 1
+        elif args[i] == "--fields" and i + 1 < len(args):
+            out_fields = args[i + 1]
+            i += 2
+        elif args[i].startswith("--fields="):
+            out_fields = args[i][9:]
+            i += 1
         elif not args[i].startswith("-"):
             pattern = args[i]
             i += 1
         else:
             i += 1
+
+    try:
+        fields = _fmt.normalize_fields(out_fields, context="find")
+    except ValueError as e:
+        _fmt.error(str(e))
+        sys.exit(1)
 
     st = _state.read_state()
 
@@ -512,7 +538,7 @@ def cmd_find(args):
             data = col.get("data", col)
             col_map[data.get("key", "")] = _nav.build_path(collections, data.get("key"))
 
-        _fmt.print_find_results(results, collections_map=col_map)
+        _fmt.print_find_results(results, collections_map=col_map, fields=fields)
     else:
         zot   = _zot()
         items = _fetch_items(zot, st["collection_key"])
@@ -521,7 +547,7 @@ def cmd_find(args):
                                                item_type=item_type)
         results = _finder.find_in_collection(items, pattern=pattern, field=field,
                                              item_type=item_type if not tags else None)
-        _fmt.print_find_results(results)
+        _fmt.print_find_results(results, fields=fields)
 
 
 def cmd_connect(args):
@@ -614,6 +640,23 @@ def cmd_config(args):
     dotpath, value = args[0], args[1]
     _config.set_value(dotpath, value)
     print(f"Set {dotpath} = {value}")
+
+
+def cmd_help(args):
+    print("""Usage: zotcli <command> [args]
+
+Navigation:  cd [path]  pwd  tree [--depth N] [--no-items]
+Listing:     ls [path] [--sort <f>] [--reverse] [--unfiled] [--fields <csv>]
+Reading:     cat <item>[:<child>]
+Searching:   find <pattern> [--field <f>] [--scope library] [--tag <t>] [--type <t>] [--fields <csv>]
+Exporting:   get <item> [--bibtex|--json|--bib] [--style <csl>]
+             get <item>:<child> [-o <path>]
+Setup:       connect  sync  off  config [key [value]]
+Python:      py  py -c '<code>'  py <script.py>
+
+Field aliases for --fields: label, title, citation_key (ck), author (creator), year, type, meta, key
+Global flags: --fresh
+""")
 
 
 # ---------------------------------------------------------------------------
@@ -712,6 +755,9 @@ COMMANDS = {
     "sync":         cmd_sync,
     "off":          cmd_off,
     "config":       cmd_config,
+    "help":         cmd_help,
+    "--help":       cmd_help,
+    "-h":           cmd_help,
     # Hidden
     "_complete":    cmd__complete,
     "_spell_dir":   cmd__spell_dir,

--- a/spells/zotcli/lib/formatters.py
+++ b/spells/zotcli/lib/formatters.py
@@ -28,6 +28,83 @@ def _c(code, text):
     return f"{code}{text}{NC}" if code else text
 
 
+LS_FIELD_ALIASES = {
+    "label": "label",
+    "name": "title",
+    "title": "title",
+    "citation_key": "citation_key",
+    "ck": "citation_key",
+    "author": "author",
+    "creator": "author",
+    "year": "year",
+    "type": "type",
+    "meta": "meta",
+    "key": "key",
+}
+
+DEFAULT_LS_FIELDS = ["label", "type", "meta"]
+DEFAULT_FIND_FIELDS = ["label", "type", "meta"]
+
+
+def normalize_fields(spec, *, context="ls"):
+    """Parse comma-separated field spec into canonical field list."""
+    default = DEFAULT_FIND_FIELDS if context == "find" else DEFAULT_LS_FIELDS
+    if not spec:
+        return default
+
+    fields = []
+    for raw in spec.split(","):
+        key = raw.strip().lower()
+        if not key:
+            continue
+        mapped = LS_FIELD_ALIASES.get(key)
+        if mapped is None:
+            raise ValueError(f"Unknown field '{raw}'. Allowed: {', '.join(sorted(LS_FIELD_ALIASES))}")
+        fields.append(mapped)
+
+    if not fields:
+        return default
+
+    # de-dup preserving order
+    seen = set()
+    out = []
+    for f in fields:
+        if f not in seen:
+            seen.add(f)
+            out.append(f)
+    return out
+
+
+def _item_field_values(item_data, *, fields, collections_map=None):
+    label = _item_label(item_data)
+    itype = item_data.get("itemType", "")
+    creators = _fmt_creators(item_data.get("creators", []))
+    year = (item_data.get("date", "") or "")[:4]
+    meta = f"{creators} ({year})" if creators else year
+    ck = get_citation_key(item_data) or ""
+    title = item_data.get("title", "")
+    item_key = item_data.get("key", "")
+
+    values = {
+        "label": _c(CYAN, label),
+        "type": _c(DIM, itype),
+        "author": creators,
+        "year": year,
+        "meta": meta,
+        "citation_key": ck,
+        "title": title,
+        "key": item_key,
+    }
+
+    if collections_map is not None:
+        item_cols = item_data.get("collections", [])
+        col_path = collections_map.get(item_cols[0], "") if item_cols else ""
+        if col_path:
+            values["meta"] = f"{values['meta']}  {_c(DIM, col_path)}" if values["meta"] else _c(DIM, col_path)
+
+    return [values.get(field, "") for field in fields]
+
+
 # ---------------------------------------------------------------------------
 # Citation key extraction
 # ---------------------------------------------------------------------------
@@ -99,7 +176,7 @@ def print_pwd(path):
 
 
 def print_ls(collections, items, sort_key="name", reverse=False,
-             current_collection_key=None):
+             current_collection_key=None, fields=None):
     """
     Mixed listing: collections (bold + /) then items.
 
@@ -123,13 +200,10 @@ def print_ls(collections, items, sort_key="name", reverse=False,
                               key=lambda it: _sort_key_for_item(it, sort_key),
                               reverse=reverse)
 
+    selected_fields = fields or DEFAULT_LS_FIELDS
+
     for item in sorted_items:
-        data     = item.get("data", item)
-        label    = _item_label(data)
-        itype    = _c(DIM, data.get("itemType", ""))
-        creators = _fmt_creators(data.get("creators", []))
-        year     = (data.get("date", "") or "")[:4]
-        meta     = f"{creators} ({year})" if creators else year
+        data = item.get("data", item)
 
         # Multi-collection indicator
         item_cols = data.get("collections", [])
@@ -138,7 +212,8 @@ def print_ls(collections, items, sort_key="name", reverse=False,
             if item_cols[0] != current_collection_key:
                 prefix = "→ "
 
-        print(f"{prefix}{_c(CYAN, label)}\t{itype}\t{meta}")
+        values = _item_field_values(data, fields=selected_fields)
+        print(f"{prefix}" + "\t".join(values))
 
 
 def print_children(children):
@@ -202,25 +277,13 @@ def print_item_info(item):
                             initial_indent="  ", subsequent_indent="  "))
 
 
-def print_find_results(items, collections_map=None):
+def print_find_results(items, collections_map=None, fields=None):
     """Like print_ls items section but includes collection path per item."""
+    selected_fields = fields or DEFAULT_FIND_FIELDS
     for item in items:
-        data     = item.get("data", item)
-        label    = _item_label(data)
-        itype    = _c(DIM, data.get("itemType", ""))
-        creators = _fmt_creators(data.get("creators", []))
-        year     = (data.get("date", "") or "")[:4]
-        meta     = f"{creators} ({year})" if creators else year
-
-        if collections_map:
-            item_cols = data.get("collections", [])
-            col_path = ""
-            if item_cols:
-                col_path = collections_map.get(item_cols[0], "")
-            if col_path:
-                meta = f"{meta}  {_c(DIM, col_path)}"
-
-        print(f"{_c(CYAN, label)}\t{itype}\t{meta}")
+        data = item.get("data", item)
+        values = _item_field_values(data, fields=selected_fields, collections_map=collections_map)
+        print("\t".join(values))
 
 
 def print_tree(collections, parent_key=None, prefix="", depth=None, _current=0,


### PR DESCRIPTION
### Motivation

- Finish and stabilize the zotcli v3 work that was left incomplete by adding top-level help handling, a prompt integration snippet, and configurable list/find output columns. 
- Provide a non-invasive way to integrate PS1 output (copy/paste via build) and make `ls`/`find` outputs configurable so users can select citation key, title, author, year, etc.

### Description

- Add entrypoint handling for `-h|--help|help` in `spells/zotcli/bin/zotcli` and introduce a `help` command in `spells/zotcli/lib/commands.py` that prints updated usage text. 
- Implement `--fields <csv>` parsing and validation via `normalize_fields` and `_item_field_values` in `spells/zotcli/lib/formatters.py`, and wire `--fields` through `ls` and `find` in `spells/zotcli/lib/commands.py` to produce configurable tabular output. 
- Add `make -C spells/zotcli prompt` target that prints a copy/paste `_update_prompt` snippet (no automatic modifications to shell rc files) in `spells/zotcli/Makefile`. 
- Update bash completions (`spells/zotcli/completions/bash/zotcli.bash`) to include `help` and `--fields` where relevant, and document the new options and prompt snippet in `spells/zotcli/README.md`.

### Testing

- Ran Python syntax checks with `python -m py_compile spells/zotcli/lib/formatters.py spells/zotcli/lib/commands.py` and they succeeded. 
- Validated shell scripts with `bash -n` on the entrypoint and completions and they passed. 
- Verified `make -C spells/zotcli prompt` outputs a usable PS1 snippet and `spells/zotcli/bin/zotcli --help` prints the new usage text. 
- Exercised `print_ls(..., fields=...)` via a small Python invocation to confirm `--fields` formatting behavior. 
- `make -C spells/zotcli test` was attempted but failed in this environment due to external dependency fetch/network tunnel errors while creating the venv (not a code failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6ae22ef70832da0a7e9a0d0b34ed7)