### PR TITLE
arcane-batch: add ls/cd/run/exec/favorites/purge and enhance discovery

### DIFF
--- a/spells/arcane-batch/README.md
+++ b/spells/arcane-batch/README.md
@@ -17,7 +17,13 @@ arcane <subcommand> [projects...] [--exclude|-e excludes...] [--device|-d device
 | `pull`    | Pull images and restart                  |
 | `restart` | Full restart (down + pull + up)           |
 | `clean`   | Remove services and images               |
+| `purge`   | Clean + remove volumes                   |
 | `status`  | Show service status                      |
+| `ls`      | List projects on device (all/up/down)    |
+| `cd`      | Print absolute path for one project      |
+| `run`     | Run arbitrary command in each project    |
+| `exec`    | Alias for `run`                          |
+| `favorites` | Generate portable bookmarks HTML (nginx URLs grouped by device/project) |
 | `dump`    | Backup all .env files to encrypted 7z    |
 | `restore` | Restore .env files from 7z archive       |
 
@@ -30,6 +36,15 @@ arcane down --exclude asmodeus      # down all except arcane UI
 arcane restart taildns              # restart only taildns
 arcane up -d lilith                 # up all projects on lilith
 arcane status                       # ps for all projects
+arcane ls                           # list projects with up/down status
+arcane ls --up                      # list only running projects
+arcane ls --down -d lilith          # list only stopped projects on lilith
+cd "$(arcane cd taildns)"           # jump to a project directory
+arcane run -- docker compose config # run command in each project
+arcane exec taildns -- docker compose logs -n 50
+arcane favorites                    # one portable HTML for browser import
+arcane favorites -o ~/Bookmarks/arcane.html
+arcane favorites -d lilith          # only one device
 arcane dump                         # backup all .env files
 arcane restore backup.7z            # restore .env files
 ```

--- a/spells/arcane-batch/bin/arcane
+++ b/spells/arcane-batch/bin/arcane
@@ -16,13 +16,22 @@ Subcommands:
   pull      Pull images and restart (pull + up -d)
   restart   Full restart (down + pull + up -d)
   clean     Remove services and images (down --rmi all)
+  purge     Clean + remove volumes (down --rmi all --volumes)
   status    Show service status (docker compose ps)
+  ls        List projects on device (optionally only up or down)
+  cd        Print absolute project path (use with: cd "$(arcane cd <project>)")
+  run       Run an arbitrary command in each selected project
+  exec      Alias for run
+  favorites Generate one portable bookmarks HTML with nginx URLs grouped by device/project
   dump      Backup all .env files to encrypted 7z archive
   restore   Restore .env files from 7z archive
 
 Options:
   -d, --device <name>     Target device (default: hostname)
   -e, --exclude <names>   Exclude projects from batch operation
+  -o, --output <path>     Output path for favorites (only with favorites)
+      --up                Only for ls: show running projects
+      --down              Only for ls: show stopped projects
 
 Environment:
   ARCANE_DIR   Arcane repository path (default: ~/arcane)
@@ -50,9 +59,80 @@ case "${1:-}" in
         shift
         _arcane_each "docker compose down --rmi all" "$@"
         ;;
+    purge)
+        shift
+        _arcane_each "docker compose down --rmi all --volumes" "$@"
+        ;;
     status)
         shift
         _arcane_each "docker compose ps" "$@"
+        ;;
+    ls)
+        shift
+        ls_mode="all"
+        seen_up=false
+        seen_down=false
+        ls_args=()
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --up)
+                    seen_up=true
+                    ls_mode="up"
+                    shift
+                    ;;
+                --down)
+                    seen_down=true
+                    ls_mode="down"
+                    shift
+                    ;;
+                *)
+                    ls_args+=("$1")
+                    shift
+                ;;
+            esac
+        done
+        if $seen_up && $seen_down; then
+            echo "error: choose only one of --up or --down" >&2
+            exit 1
+        fi
+        _arcane_ls "$ls_mode" "${ls_args[@]}"
+        ;;
+    cd)
+        shift
+        _arcane_cd "$@"
+        ;;
+    run|exec)
+        shift
+        if [[ $# -eq 0 ]]; then
+            echo "error: run/exec requires a command. Use: arcane run [filters...] -- <command>" >&2
+            exit 1
+        fi
+
+        args=("$@")
+        split=-1
+        for i in "${!args[@]}"; do
+            if [[ "${args[$i]}" == "--" ]]; then
+                split="$i"
+                break
+            fi
+        done
+
+        if [[ "$split" -lt 0 ]]; then
+            echo "error: missing '--' separator. Example: arcane run -d $(hostname) -- docker compose config" >&2
+            exit 1
+        fi
+
+        filters=("${args[@]:0:split}")
+        cmd=("${args[@]:split+1}")
+        if [[ ${#cmd[@]} -eq 0 ]]; then
+            echo "error: missing command after '--'" >&2
+            exit 1
+        fi
+        _arcane_each "${cmd[*]}" "${filters[@]}"
+        ;;
+    favorites)
+        shift
+        _arcane_favorites "$@"
         ;;
     dump)
         _arcane_dump

--- a/spells/arcane-batch/lib/core.bash
+++ b/spells/arcane-batch/lib/core.bash
@@ -86,7 +86,19 @@ _arcane_discover() {
         done
         $ignored && continue
 
-        [[ -f "$entry/compose.yaml" ]] && printf '%s\t%s\n' "$name" "$entry"
+        [[ -f "$entry/compose.yaml" ]] && printf '%s\t%s\n' "$name" "${entry%/}"
+    done
+}
+
+# Prints "device\tpath" lines for all discovered devices
+_arcane_discover_devices() {
+    local entry
+    for entry in "$ARCANE_DIR"/*/; do
+        [[ ! -d "$entry" ]] && continue
+        local name
+        name="$(basename "$entry")"
+        [[ "$name" == .* ]] && continue
+        printf '%s\t%s\n' "$name" "${entry%/}"
     done
 }
 
@@ -169,6 +181,227 @@ _arcane_each() {
     fi
 
     [[ $fail -eq 0 ]]
+}
+
+_arcane_project_status() {
+    local path="$1"
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "unknown"
+        return 0
+    fi
+    local ids
+    ids="$(cd "$path" && docker compose ps -q 2>/dev/null || true)"
+    if [[ -n "${ids//[[:space:]]/}" ]]; then
+        echo "up"
+    else
+        echo "down"
+    fi
+}
+
+_arcane_ls() {
+    local mode="${1:-all}"
+    shift || true
+
+    _arcane_parse_args "$@" || return 1
+
+    local projects
+    projects="$(_arcane_discover "$ARCANE_DEVICE")" || return 1
+    [[ -z "$projects" ]] && { echo "no projects found for device: $ARCANE_DEVICE" >&2; return 1; }
+
+    while IFS=$'\t' read -r name path; do
+        [[ -z "$name" || -z "$path" ]] && continue
+
+        if [[ ${#ARCANE_INCLUDES[@]} -gt 0 ]]; then
+            local found=false
+            local inc
+            for inc in "${ARCANE_INCLUDES[@]}"; do
+                [[ "$name" == "$inc" ]] && { found=true; break; }
+            done
+            $found || continue
+        elif [[ ${#ARCANE_EXCLUDES[@]} -gt 0 ]]; then
+            local excluded=false
+            local exc
+            for exc in "${ARCANE_EXCLUDES[@]}"; do
+                [[ "$name" == "$exc" ]] && { excluded=true; break; }
+            done
+            $excluded && continue
+        fi
+
+        local status
+        status="$(_arcane_project_status "$path")"
+        case "$mode" in
+            up) [[ "$status" == "up" ]] || continue ;;
+            down) [[ "$status" == "down" ]] || continue ;;
+        esac
+        printf '%-8s %s\n' "$status" "$name"
+    done <<< "$projects"
+}
+
+_arcane_cd() {
+    _arcane_parse_args "$@" || return 1
+
+    if [[ ${#ARCANE_EXCLUDES[@]} -gt 0 ]]; then
+        echo "error: arcane cd does not support --exclude" >&2
+        return 1
+    fi
+    if [[ ${#ARCANE_INCLUDES[@]} -ne 1 ]]; then
+        echo "error: arcane cd requires exactly one project name" >&2
+        return 1
+    fi
+
+    local project="${ARCANE_INCLUDES[0]}"
+    local projects
+    projects="$(_arcane_discover "$ARCANE_DEVICE")" || return 1
+
+    while IFS=$'\t' read -r name path; do
+        [[ "$name" == "$project" ]] || continue
+        printf '%s\n' "$path"
+        return 0
+    done <<< "$projects"
+
+    echo "error: project not found on device '$ARCANE_DEVICE': $project" >&2
+    return 1
+}
+
+_arcane_html_escape() {
+    local s="$1"
+    s="${s//&/&amp;}"
+    s="${s//</&lt;}"
+    s="${s//>/&gt;}"
+    s="${s//\"/&quot;}"
+    printf '%s' "$s"
+}
+
+_arcane_collect_nginx_urls() {
+    local project_path="$1"
+
+    # 1) Explicit URLs in compose/env/nginx-related files
+    local file
+    while IFS= read -r -d '' file; do
+        rg -oN --no-filename 'https?://[A-Za-z0-9._~:/?#\[\]@!$&()*+,;=%-]+' "$file" || true
+    done < <(find "$project_path" -maxdepth 5 -type f \
+        \( -name 'compose.yaml' -o -name 'compose.yml' -o -name '*.conf' -o -name '.env' -o -name '.env.*' -o -name '*.env' \) \
+        -print0)
+
+    # 2) nginx server_name directives -> infer http URLs
+    while IFS= read -r line; do
+        line="${line#server_name }"
+        line="${line%;}"
+        local host
+        for host in $line; do
+            [[ -z "$host" || "$host" == "_" || "$host" == "localhost" ]] && continue
+            [[ "$host" =~ [*] ]] && continue
+            printf 'http://%s\n' "$host"
+        done
+    done < <(rg -oN --no-filename 'server_name[[:space:]]+[^;]+;' "$project_path" || true)
+
+    # 3) Traefik Host(`domain`) labels
+    while IFS= read -r host; do
+        [[ -z "$host" || "$host" == "localhost" ]] && continue
+        printf 'http://%s\n' "$host"
+    done < <(rg -oN --no-filename 'Host\(`[^`]+`\)' "$project_path" | sed -E 's/Host\(`([^`]+)`\)/\1/' || true)
+}
+
+_arcane_write_bookmark_entry() {
+    local url="$1"
+    local label="$2"
+    printf '<DT><A HREF="%s">%s</A>\n' "$(_arcane_html_escape "$url")" "$(_arcane_html_escape "$label")"
+}
+
+_arcane_favorites() {
+    local device_filter=""
+    local output="$ARCANE_DIR/arcane-nginx-bookmarks.html"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --device|-d)
+                [[ $# -lt 2 ]] && { echo "error: --device requires a value" >&2; return 1; }
+                device_filter="$2"
+                shift 2
+                ;;
+            --output|-o)
+                [[ $# -lt 2 ]] && { echo "error: --output requires a value" >&2; return 1; }
+                output="$2"
+                shift 2
+                ;;
+            *)
+                echo "error: unknown option: $1" >&2
+                return 1
+                ;;
+        esac
+    done
+
+    local devices=()
+    local discovered
+    discovered="$(_arcane_discover_devices)"
+    if [[ -z "$discovered" ]]; then
+        echo "error: no device directories found in $ARCANE_DIR" >&2
+        return 1
+    fi
+
+    while IFS=$'\t' read -r name _path; do
+        if [[ -n "$device_filter" && "$name" != "$device_filter" ]]; then
+            continue
+        fi
+        devices+=("$name")
+    done <<< "$discovered"
+
+    if [[ ${#devices[@]} -eq 0 ]]; then
+        echo "error: device not found: $device_filter" >&2
+        return 1
+    fi
+
+    mkdir -p "$(dirname "$output")"
+    {
+        echo '<!DOCTYPE NETSCAPE-Bookmark-file-1>'
+        echo '<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">'
+        echo '<TITLE>Bookmarks</TITLE>'
+        echo '<H1>Bookmarks</H1>'
+        echo '<DL><p>'
+        echo '<DT><H3>arcane</H3>'
+        echo '<DL><p>'
+    } > "$output"
+
+    local total=0
+    local device
+    for device in "${devices[@]}"; do
+        local projects
+        projects="$(_arcane_discover "$device" || true)"
+        [[ -z "$projects" ]] && continue
+
+        {
+            printf '<DT><H3>%s</H3>\n' "$(_arcane_html_escape "$device")"
+            echo '<DL><p>'
+        } >> "$output"
+
+        while IFS=$'\t' read -r project path; do
+            [[ -z "$project" || -z "$path" ]] && continue
+            mapfile -t urls < <(_arcane_collect_nginx_urls "$path" | awk 'NF' | sort -u)
+            [[ ${#urls[@]} -eq 0 ]] && continue
+
+            {
+                printf '<DT><H3>%s</H3>\n' "$(_arcane_html_escape "$project")"
+                echo '<DL><p>'
+            } >> "$output"
+
+            local url
+            for url in "${urls[@]}"; do
+                _arcane_write_bookmark_entry "$url" "$url" >> "$output"
+                ((total++))
+            done
+
+            echo '</DL><p>' >> "$output"
+        done <<< "$projects"
+
+        echo '</DL><p>' >> "$output"
+    done
+
+    {
+        echo '</DL><p>'
+        echo '</DL><p>'
+    } >> "$output"
+
+    echo "Bookmarks generated: $output ($total URL(s))"
 }
 
 # --- Dump ---


### PR DESCRIPTION
### Motivation

- Add several convenience subcommands to make batch operations and navigation across devices/projects easier and to enable portable bookmark generation from detected nginx/Traefik URLs.
- Improve project discovery robustness by normalizing discovered paths and adding device-level discovery for cross-device features.

### Description

- Added new subcommands in `spells/arcane-batch/bin/arcane`: `ls`, `cd`, `run`/`exec`, `favorites`, and `purge`, and extended the usage help and examples in `README.md`.
- Implemented core helpers in `spells/arcane-batch/lib/core.bash`: `_arcane_discover_devices`, `_arcane_project_status`, `_arcane_ls`, `_arcane_cd`, `_arcane_html_escape`, `_arcane_collect_nginx_urls`, `_arcane_write_bookmark_entry`, and `_arcane_favorites` to support listing, path lookup, arbitrary command execution, and bookmark HTML generation.
- Fixed discovery output to strip trailing slashes from project paths and added URL extraction logic that scans compose/env/nginx/Traefik labels to produce portable bookmark entries.
- `purge` runs `docker compose down --rmi all --volumes`, `run`/`exec` accept a `--` separator for arbitrary commands, and `favorites` writes a Netscape-format bookmarks HTML grouped by device/project with an `--output` option.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbf40de5348325af18034970aff46d)